### PR TITLE
Surface Output from Vagrant on Vagrant Up

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -31,7 +31,7 @@ for TEST_NAME in $TESTS ; do
   ansible-playbook --syntax-check -i inventory playbook.yml
 
   vagrant destroy --force &> /dev/null
-  vagrant up --no-provision &> /dev/null
+  vagrant up --no-provision
   vagrant provision
   rm ./playbook.yml
 done


### PR DESCRIPTION
There's way too much time without feedback during runtests.sh. If we're suppressing the sheet amount of messages from "vagrant destroy/up", maybe replace it with something else?
